### PR TITLE
Implement GET API routes and update models

### DIFF
--- a/src/app/api/contacts/[id]/route.ts
+++ b/src/app/api/contacts/[id]/route.ts
@@ -2,6 +2,17 @@ import { NextRequest, NextResponse } from "next/server";
 import { connectToDatabase } from "@/lib/db";
 import Contact from "@/lib/models/Contact";
 
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  await connectToDatabase();
+  const contact = await Contact.findById(params.id);
+  if (!contact)
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(contact);
+}
+
 export async function PUT(
   req: NextRequest,
   { params }: { params: { id: string } }

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -2,25 +2,17 @@ import { NextRequest, NextResponse } from "next/server";
 import { connectToDatabase } from "@/lib/db";
 import Contact from "@/lib/models/Contact";
 
-// export async function GET(req: NextRequest) {
-//   await connectToDatabase();
-//   const { searchParams } = new URL(req.url);
-//   const userId = searchParams.get("userId");
-//   if (!userId)
-//     return NextResponse.json({ error: "Missing userId" }, { status: 400 });
+export async function GET(req: NextRequest) {
+  await connectToDatabase();
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get("userId");
 
-//   const contacts = await Contact.find({ userId });
-//   return NextResponse.json(contacts);
-// }
+  const filter: Record<string, unknown> = {};
+  if (userId) filter.userId = userId;
 
-// export async function POST(req: NextRequest) {
-//   await connectToDatabase();
-//   const body = await req.json();
-//   const { userId, name, email, phone } = body;
-
-//   const contact = await Contact.create({ userId, name, email, phone });
-//   return NextResponse.json(contact, { status: 201 });
-// }
+  const contacts = await Contact.find(filter);
+  return NextResponse.json(contacts);
+}
 export async function POST(req: NextRequest) {
   await connectToDatabase();
   const { userId, name, email, phone } = await req.json();

--- a/src/app/api/notes/[id]/route.ts
+++ b/src/app/api/notes/[id]/route.ts
@@ -2,28 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { connectToDatabase } from "@/lib/db";
 import Note from "@/lib/models/Note";
 
-// export async function PUT(
-//   req: NextRequest,
-//   { params }: { params: { id: string } }
-// ) {
-//   await connectToDatabase();
-//   const body = await req.json();
-//   const updated = await Note.findByIdAndUpdate(
-//     params.id,
-//     { text: body.text },
-//     { new: true }
-//   );
-//   return NextResponse.json(updated);
-// }
-
-// export async function DELETE(
-//   req: NextRequest,
-//   { params }: { params: { id: string } }
-// ) {
-//   await connectToDatabase();
-//   await Note.findByIdAndDelete(params.id);
-//   return new Response(null, { status: 204 });
-// }
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  await connectToDatabase();
+  const note = await Note.findById(params.id);
+  if (!note) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(note);
+}
 
 export async function PUT(
   req: NextRequest,
@@ -37,4 +24,13 @@ export async function PUT(
     { new: true }
   );
   return NextResponse.json(updated);
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  await connectToDatabase();
+  await Note.findByIdAndDelete(params.id);
+  return new Response(null, { status: 204 });
 }

--- a/src/app/api/notes/route.ts
+++ b/src/app/api/notes/route.ts
@@ -2,25 +2,17 @@ import { NextRequest, NextResponse } from "next/server";
 import { connectToDatabase } from "@/lib/db";
 import Note from "@/lib/models/Note";
 
-// export async function GET(req: NextRequest) {
-//   await connectToDatabase();
-//   const { searchParams } = new URL(req.url);
-//   const userId = searchParams.get("userId");
-//   if (!userId)
-//     return NextResponse.json({ error: "Missing userId" }, { status: 400 });
+export async function GET(req: NextRequest) {
+  await connectToDatabase();
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get("userId");
 
-//   const notes = await Note.find({ userId });
-//   return NextResponse.json(notes);
-// }
+  const filter: Record<string, unknown> = {};
+  if (userId) filter.userId = userId;
 
-// export async function POST(req: NextRequest) {
-//   await connectToDatabase();
-//   const body = await req.json();
-//   const { userId, text } = body;
-
-//   const note = await Note.create({ userId, text });
-//   return NextResponse.json(note, { status: 201 });
-// }
+  const notes = await Note.find(filter);
+  return NextResponse.json(notes);
+}
 
 export async function POST(req: NextRequest) {
   await connectToDatabase();

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -2,6 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { connectToDatabase } from "@/lib/db";
 import Task from "@/lib/models/Task";
 
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  await connectToDatabase();
+  const task = await Task.findById(params.id);
+  if (!task) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(task);
+}
+
 export async function PUT(
   req: NextRequest,
   { params }: { params: { id: string } }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -2,25 +2,17 @@ import { NextRequest, NextResponse } from "next/server";
 import { connectToDatabase } from "@/lib/db";
 import Task from "@/lib/models/Task";
 
-// export async function GET(req: NextRequest) {
-//   await connectToDatabase();
-//   const { searchParams } = new URL(req.url);
-//   const userId = searchParams.get("userId");
-//   if (!userId)
-//     return NextResponse.json({ error: "Missing userId" }, { status: 400 });
+export async function GET(req: NextRequest) {
+  await connectToDatabase();
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get("userId");
 
-//   const tasks = await Task.find({ userId });
-//   return NextResponse.json(tasks);
-// }
+  const filter: Record<string, unknown> = {};
+  if (userId) filter.userId = userId;
 
-// export async function POST(req: NextRequest) {
-//   await connectToDatabase();
-//   const body = await req.json();
-//   const { userId, title, dueDate, status } = body;
-
-//   const task = await Task.create({ userId, title, dueDate, status });
-//   return NextResponse.json(task, { status: 201 });
-// }
+  const tasks = await Task.find(filter);
+  return NextResponse.json(tasks);
+}
 export async function POST(req: NextRequest) {
   await connectToDatabase();
   const { userId, title, description, status, priority, dueDate } =

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,10 +1,17 @@
 import mongoose from "mongoose";
 
+type MongooseConnection = {
+  conn: typeof mongoose | null;
+  promise: Promise<typeof mongoose> | null;
+};
+
 const MONGODB_URI = process.env.MONGODB_URI as string;
 
 if (!MONGODB_URI) throw new Error("Missing MONGODB_URI in environment.");
+const globalWithMongoose = global as unknown as { mongoose?: MongooseConnection };
 
-let cached = (global as any).mongoose || { conn: null, promise: null };
+const cached: MongooseConnection =
+  globalWithMongoose.mongoose || { conn: null, promise: null };
 
 export async function connectToDatabase() {
   if (cached.conn) return cached.conn;
@@ -19,5 +26,6 @@ export async function connectToDatabase() {
   }
 
   cached.conn = await cached.promise;
+  globalWithMongoose.mongoose = cached;
   return cached.conn;
 }

--- a/src/lib/models/Note.ts
+++ b/src/lib/models/Note.ts
@@ -3,7 +3,8 @@ import mongoose, { Schema, models } from "mongoose";
 const NoteSchema = new Schema(
   {
     userId: { type: String, required: true },
-    text: { type: String, required: true },
+    title: { type: String, required: true },
+    content: { type: String, required: true },
   },
   { timestamps: true }
 );

--- a/src/lib/models/Task.ts
+++ b/src/lib/models/Task.ts
@@ -4,7 +4,13 @@ const TaskSchema = new Schema(
   {
     userId: { type: String, required: true },
     title: { type: String, required: true },
-    dueDate: { type: Date, required: true },
+    description: { type: String },
+    priority: {
+      type: String,
+      enum: ["low", "medium", "high"],
+      default: "medium",
+    },
+    dueDate: { type: Date },
     status: {
       type: String,
       enum: ["pending", "in-progress", "completed"],


### PR DESCRIPTION
## Summary
- add GET handlers for notes, tasks and contacts API routes
- support retrieving single records via ID routes
- allow deleting notes by ID
- extend Note and Task mongoose schemas for new fields
- fix DB connection helper typing to satisfy lint rules

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6887e7e5073c832fb6c23d55d5165146