### PR TITLE
Fix missing token for SWA close job

### DIFF
--- a/.github/workflows/azure-static-web-apps-proud-grass-0ea56950f.yml
+++ b/.github/workflows/azure-static-web-apps-proud-grass-0ea56950f.yml
@@ -55,4 +55,6 @@ jobs:
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROUD_GRASS_0EA56950F }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "close"


### PR DESCRIPTION
## Summary
- supply required tokens for the `close_pull_request_job` step

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888c64b5cd8832faedddecedc97b911