### PR TITLE
Ensure DB name configurable via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project is a single page application built with **Next.js** and **TypeScrip
 cp .env.example .env
 ```
 
-At minimum you need to provide your MongoDB connection string and Firebase credentials.
+At minimum you need to provide your MongoDB connection string and Firebase credentials. The database name defaults to `pim-app`, but you can override it by setting `DATABASE_NAME` in your `.env` file.
 
 2. Install dependencies and run the development server:
 

--- a/azure-functions/lib/db.ts
+++ b/azure-functions/lib/db.ts
@@ -2,11 +2,12 @@
 import mongoose from "mongoose";
 
 const MONGODB_URI = process.env.MONGODB_URI!;
+const DB_NAME = process.env.DATABASE_NAME || "pim-app";
 
 export async function connectToDatabase() {
   if (mongoose.connection.readyState >= 1) return;
 
   return mongoose.connect(MONGODB_URI, {
-    dbName: "pim",
+    dbName: DB_NAME,
   });
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -6,6 +6,7 @@ type MongooseConnection = {
 };
 
 const MONGODB_URI = process.env.MONGODB_URI as string | undefined;
+const DB_NAME = process.env.DATABASE_NAME || "pim-app";
 const globalWithMongoose = global as unknown as { mongoose?: MongooseConnection };
 
 const cached: MongooseConnection =
@@ -20,7 +21,7 @@ export async function connectToDatabase() {
   if (!cached.promise) {
     cached.promise = mongoose
       .connect(MONGODB_URI, {
-        dbName: "pim-app",
+        dbName: DB_NAME,
         bufferCommands: false,
       })
       .then((mongoose) => mongoose);


### PR DESCRIPTION
## Summary
- allow configurable database name for Next.js API and Azure Functions
- mention DATABASE_NAME env var in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a43c278f8832fb442bf40d5858552