### PR TITLE
Improve API route error handling

### DIFF
--- a/src/app/api/contacts/[id]/route.ts
+++ b/src/app/api/contacts/[id]/route.ts
@@ -8,33 +8,57 @@ export async function GET(
   req: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await context.params;
-  await connectToDatabase();
-  const contact = await Contact.findById(id);
-  if (!contact)
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(contact);
+  try {
+    const { id } = await context.params;
+    await connectToDatabase();
+    const contact = await Contact.findById(id);
+    if (!contact)
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(contact);
+  } catch (error) {
+    console.error(`GET /api/contacts/${context.params} error`, error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }
 
 export async function PUT(
   req: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await context.params;
-  await connectToDatabase();
-  const body = await req.json();
-  const updated = await Contact.findByIdAndUpdate(id, body, {
-    new: true,
-  });
-  return NextResponse.json(updated);
+  try {
+    const { id } = await context.params;
+    await connectToDatabase();
+    const body = await req.json();
+    const updated = await Contact.findByIdAndUpdate(id, body, {
+      new: true,
+    });
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error(`PUT /api/contacts/${context.params} error`, error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }
 
 export async function DELETE(
   req: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await context.params;
-  await connectToDatabase();
-  await Contact.findByIdAndDelete(id);
-  return new Response(null, { status: 204 });
+  try {
+    const { id } = await context.params;
+    await connectToDatabase();
+    await Contact.findByIdAndDelete(id);
+    return new Response(null, { status: 204 });
+  } catch (error) {
+    console.error(`DELETE /api/contacts/${context.params} error`, error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -3,29 +3,47 @@ import { connectToDatabase } from "@/lib/db";
 import Contact from "@/lib/models/Contact";
 
 export async function GET(req: NextRequest) {
-  await connectToDatabase();
-  const { searchParams } = new URL(req.url);
-  const userId = searchParams.get("userId");
+  try {
+    await connectToDatabase();
+    const { searchParams } = new URL(req.url);
+    const userId = searchParams.get("userId");
 
-  const filter: Record<string, unknown> = {};
-  if (userId) filter.userId = userId;
+    const filter: Record<string, unknown> = {};
+    if (userId) filter.userId = userId;
 
-  const contacts = await Contact.find(filter);
-  return NextResponse.json(contacts);
+    const contacts = await Contact.find(filter);
+    return NextResponse.json(contacts);
+  } catch (error) {
+    console.error("GET /api/contacts error", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }
-export async function POST(req: NextRequest) {
-  await connectToDatabase();
-  const { userId, name, email, phone } = await req.json();
-  if (!userId || !name || !email)
-    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
 
-  const contact = await Contact.create({
-    userId,
-    name,
-    email,
-    phone,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return NextResponse.json(contact);
+export async function POST(req: NextRequest) {
+  try {
+    await connectToDatabase();
+    const { userId, name, email, phone } = await req.json();
+    if (!userId || !name || !email) {
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+    }
+
+    const contact = await Contact.create({
+      userId,
+      name,
+      email,
+      phone,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return NextResponse.json(contact);
+  } catch (error) {
+    console.error("POST /api/contacts error", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/notes/[id]/route.ts
+++ b/src/app/api/notes/[id]/route.ts
@@ -8,34 +8,59 @@ export async function GET(
   req: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await context.params;
-  await connectToDatabase();
-  const note = await Note.findById(id);
-  if (!note) return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(note);
+  try {
+    const { id } = await context.params;
+    await connectToDatabase();
+    const note = await Note.findById(id);
+    if (!note)
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(note);
+  } catch (error) {
+    console.error(`GET /api/notes/${context.params} error`, error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }
 
 export async function PUT(
   req: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await context.params;
-  await connectToDatabase();
-  const { title, content } = await req.json();
-  const updated = await Note.findByIdAndUpdate(
-    id,
-    { title, content, updatedAt: new Date() },
-    { new: true }
-  );
-  return NextResponse.json(updated);
+  try {
+    const { id } = await context.params;
+    await connectToDatabase();
+    const { title, content } = await req.json();
+    const updated = await Note.findByIdAndUpdate(
+      id,
+      { title, content, updatedAt: new Date() },
+      { new: true }
+    );
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error(`PUT /api/notes/${context.params} error`, error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }
 
 export async function DELETE(
   req: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await context.params;
-  await connectToDatabase();
-  await Note.findByIdAndDelete(id);
-  return new Response(null, { status: 204 });
+  try {
+    const { id } = await context.params;
+    await connectToDatabase();
+    await Note.findByIdAndDelete(id);
+    return new Response(null, { status: 204 });
+  } catch (error) {
+    console.error(`DELETE /api/notes/${context.params} error`, error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/notes/route.ts
+++ b/src/app/api/notes/route.ts
@@ -3,29 +3,45 @@ import { connectToDatabase } from "@/lib/db";
 import Note from "@/lib/models/Note";
 
 export async function GET(req: NextRequest) {
-  await connectToDatabase();
-  const { searchParams } = new URL(req.url);
-  const userId = searchParams.get("userId");
+  try {
+    await connectToDatabase();
+    const { searchParams } = new URL(req.url);
+    const userId = searchParams.get("userId");
 
-  const filter: Record<string, unknown> = {};
-  if (userId) filter.userId = userId;
+    const filter: Record<string, unknown> = {};
+    if (userId) filter.userId = userId;
 
-  const notes = await Note.find(filter);
-  return NextResponse.json(notes);
+    const notes = await Note.find(filter);
+    return NextResponse.json(notes);
+  } catch (error) {
+    console.error("GET /api/notes error", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }
 
 export async function POST(req: NextRequest) {
-  await connectToDatabase();
-  const { userId, title, content } = await req.json();
-  if (!userId || !title || !content)
-    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  try {
+    await connectToDatabase();
+    const { userId, title, content } = await req.json();
+    if (!userId || !title || !content)
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
 
-  const note = await Note.create({
-    userId,
-    title,
-    content,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return NextResponse.json(note);
+    const note = await Note.create({
+      userId,
+      title,
+      content,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return NextResponse.json(note);
+  } catch (error) {
+    console.error("POST /api/notes error", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -8,39 +8,63 @@ export async function GET(
   req: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await context.params;
-  await connectToDatabase();
-  const task = await Task.findById(id);
-  if (!task) return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(task);
+  try {
+    const { id } = await context.params;
+    await connectToDatabase();
+    const task = await Task.findById(id);
+    if (!task) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(task);
+  } catch (error) {
+    console.error(`GET /api/tasks/${context.params} error`, error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }
 
 export async function PUT(
   req: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await context.params;
-  await connectToDatabase();
-  const body = await req.json();
-  const updated = await Task.findByIdAndUpdate(
-    id,
-    {
-      title: body.title,
-      dueDate: body.dueDate,
-      status: body.status,
-    },
-    { new: true }
-  );
+  try {
+    const { id } = await context.params;
+    await connectToDatabase();
+    const body = await req.json();
+    const updated = await Task.findByIdAndUpdate(
+      id,
+      {
+        title: body.title,
+        dueDate: body.dueDate,
+        status: body.status,
+      },
+      { new: true }
+    );
 
-  return NextResponse.json(updated);
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error(`PUT /api/tasks/${context.params} error`, error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }
 
 export async function DELETE(
   req: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
-  const { id } = await context.params;
-  await connectToDatabase();
-  await Task.findByIdAndDelete(id);
-  return new Response(null, { status: 204 });
+  try {
+    const { id } = await context.params;
+    await connectToDatabase();
+    await Task.findByIdAndDelete(id);
+    return new Response(null, { status: 204 });
+  } catch (error) {
+    console.error(`DELETE /api/tasks/${context.params} error`, error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -3,32 +3,49 @@ import { connectToDatabase } from "@/lib/db";
 import Task from "@/lib/models/Task";
 
 export async function GET(req: NextRequest) {
-  await connectToDatabase();
-  const { searchParams } = new URL(req.url);
-  const userId = searchParams.get("userId");
+  try {
+    await connectToDatabase();
+    const { searchParams } = new URL(req.url);
+    const userId = searchParams.get("userId");
 
-  const filter: Record<string, unknown> = {};
-  if (userId) filter.userId = userId;
+    const filter: Record<string, unknown> = {};
+    if (userId) filter.userId = userId;
 
-  const tasks = await Task.find(filter);
-  return NextResponse.json(tasks);
+    const tasks = await Task.find(filter);
+    return NextResponse.json(tasks);
+  } catch (error) {
+    console.error("GET /api/tasks error", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }
-export async function POST(req: NextRequest) {
-  await connectToDatabase();
-  const { userId, title, description, status, priority, dueDate } =
-    await req.json();
-  if (!userId || !title)
-    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
 
-  const task = await Task.create({
-    userId,
-    title,
-    description,
-    status: status || "pending",
-    priority: priority || "medium",
-    dueDate,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return NextResponse.json(task);
+export async function POST(req: NextRequest) {
+  try {
+    await connectToDatabase();
+    const { userId, title, description, status, priority, dueDate } =
+      await req.json();
+    if (!userId || !title)
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+
+    const task = await Task.create({
+      userId,
+      title,
+      description,
+      status: status || "pending",
+      priority: priority || "medium",
+      dueDate,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return NextResponse.json(task);
+  } catch (error) {
+    console.error("POST /api/tasks error", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- add try/catch wrappers around contacts, notes and tasks API handlers
- return 500 responses instead of crashing when database calls fail

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a57e65c3c832fb9e1775f74abf7fa