### PR TITLE
Improve API route error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Example environment configuration
+
+# MongoDB / Cosmos DB connection string
+MONGODB_URI="mongodb://<username>:<password>@<host>:<port>/?ssl=true&replicaSet=globaldb"
+# Database name (optional)
+DATABASE_NAME=pim
+
+# Firebase credentials (optional for auth features)
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
+NEXT_PUBLIC_FIREBASE_APP_ID=
+
+# API base URL for frontend service calls (only if overriding default)
+REACT_APP_API_URL=https://pim-app-woad.vercel.app/api

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ pnpm-lock.yaml
 
 # Environment variables & secrets
 .env*
+!.env.example
 .azure/
 
 # OS & IDE clutter
@@ -72,6 +73,7 @@ dist/ # Added from remote
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 .azure/ # Added from remote
 
 # vercel

--- a/README.md
+++ b/README.md
@@ -90,3 +90,13 @@ This project provides a simple personal information manager built with Next.js a
 4. **Configuration** – Set environment variables (`MONGODB_URI`, `DATABASE_NAME`, etc.) in App Service settings or store them in Azure Key Vault.
 
 With both services deployed, the frontend can call the serverless API to manage notes, contacts and tasks stored in Cosmos DB.
+
+### Environment Setup
+
+Copy `.env.example` to `.env.local` and provide the required values:
+
+```bash
+cp .env.example .env.local
+```
+
+At a minimum, set `MONGODB_URI` to your Cosmos DB connection string. Without this the API routes (e.g. `/api/contacts` and `/api/tasks`) will return a 500 error.

--- a/src/app/api/contacts/[id]/route.ts
+++ b/src/app/api/contacts/[id]/route.ts
@@ -6,36 +6,60 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await connectToDatabase();
-  const contact = await Contact.findById(params.id);
-  if (!contact) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  try {
+    await connectToDatabase();
+    const contact = await Contact.findById(params.id);
+    if (!contact) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    return NextResponse.json(contact);
+  } catch (err: any) {
+    console.error("GET /api/contacts/[id] error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
   }
-  return NextResponse.json(contact);
 }
 
 export async function PUT(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await connectToDatabase();
-  const body = await req.json();
-  const updated = await Contact.findByIdAndUpdate(
-    params.id,
-    { ...body, updatedAt: new Date() },
-    {
-      new: true,
-      runValidators: true,
-    }
-  );
-  return NextResponse.json(updated);
+  try {
+    await connectToDatabase();
+    const body = await req.json();
+    const updated = await Contact.findByIdAndUpdate(
+      params.id,
+      { ...body, updatedAt: new Date() },
+      {
+        new: true,
+        runValidators: true,
+      }
+    );
+    return NextResponse.json(updated);
+  } catch (err: any) {
+    console.error("PUT /api/contacts/[id] error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }
 
 export async function DELETE(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await connectToDatabase();
-  await Contact.findByIdAndDelete(params.id);
-  return new Response(null, { status: 204 });
+  try {
+    await connectToDatabase();
+    await Contact.findByIdAndDelete(params.id);
+    return new Response(null, { status: 204 });
+  } catch (err: any) {
+    console.error("DELETE /api/contacts/[id] error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -3,12 +3,20 @@ import { connectToDatabase } from "@/lib/db";
 import Contact from "@/lib/models/Contact";
 
 export async function GET(req: NextRequest) {
-  await connectToDatabase();
-  const { searchParams } = new URL(req.url);
-  const userId = searchParams.get("userId");
-  const query = userId ? { userId } : {};
-  const contacts = await Contact.find(query);
-  return NextResponse.json(contacts);
+  try {
+    await connectToDatabase();
+    const { searchParams } = new URL(req.url);
+    const userId = searchParams.get("userId");
+    const query = userId ? { userId } : {};
+    const contacts = await Contact.find(query);
+    return NextResponse.json(contacts);
+  } catch (err: any) {
+    console.error("GET /api/contacts error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }
 
 // export async function GET(req: NextRequest) {
@@ -31,18 +39,26 @@ export async function GET(req: NextRequest) {
 //   return NextResponse.json(contact, { status: 201 });
 // }
 export async function POST(req: NextRequest) {
-  await connectToDatabase();
-  const { userId, name, email, phone } = await req.json();
-  if (!userId || !name || !email)
-    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  try {
+    await connectToDatabase();
+    const { userId, name, email, phone } = await req.json();
+    if (!userId || !name || !email)
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
 
-  const contact = await Contact.create({
-    userId,
-    name,
-    email,
-    phone,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return NextResponse.json(contact);
+    const contact = await Contact.create({
+      userId,
+      name,
+      email,
+      phone,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return NextResponse.json(contact);
+  } catch (err: any) {
+    console.error("POST /api/contacts error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/notes/[id]/route.ts
+++ b/src/app/api/notes/[id]/route.ts
@@ -6,12 +6,20 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await connectToDatabase();
-  const note = await Note.findById(params.id);
-  if (!note) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  try {
+    await connectToDatabase();
+    const note = await Note.findById(params.id);
+    if (!note) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    return NextResponse.json(note);
+  } catch (err: any) {
+    console.error("GET /api/notes/[id] error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
   }
-  return NextResponse.json(note);
 }
 
 
@@ -19,21 +27,37 @@ export async function PUT(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await connectToDatabase();
-  const { title, content } = await req.json();
-  const updated = await Note.findByIdAndUpdate(
-    params.id,
-    { title, content, updatedAt: new Date() },
-    { new: true, runValidators: true }
-  );
-  return NextResponse.json(updated);
+  try {
+    await connectToDatabase();
+    const { title, content } = await req.json();
+    const updated = await Note.findByIdAndUpdate(
+      params.id,
+      { title, content, updatedAt: new Date() },
+      { new: true, runValidators: true }
+    );
+    return NextResponse.json(updated);
+  } catch (err: any) {
+    console.error("PUT /api/notes/[id] error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }
 
 export async function DELETE(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await connectToDatabase();
-  await Note.findByIdAndDelete(params.id);
-  return new Response(null, { status: 204 });
+  try {
+    await connectToDatabase();
+    await Note.findByIdAndDelete(params.id);
+    return new Response(null, { status: 204 });
+  } catch (err: any) {
+    console.error("DELETE /api/notes/[id] error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/notes/route.ts
+++ b/src/app/api/notes/route.ts
@@ -3,12 +3,20 @@ import { connectToDatabase } from "@/lib/db";
 import Note from "@/lib/models/Note";
 
 export async function GET(req: NextRequest) {
-  await connectToDatabase();
-  const { searchParams } = new URL(req.url);
-  const userId = searchParams.get("userId");
-  const query = userId ? { userId } : {};
-  const notes = await Note.find(query);
-  return NextResponse.json(notes);
+  try {
+    await connectToDatabase();
+    const { searchParams } = new URL(req.url);
+    const userId = searchParams.get("userId");
+    const query = userId ? { userId } : {};
+    const notes = await Note.find(query);
+    return NextResponse.json(notes);
+  } catch (err: any) {
+    console.error("GET /api/notes error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }
 
 // export async function GET(req: NextRequest) {
@@ -32,17 +40,25 @@ export async function GET(req: NextRequest) {
 // }
 
 export async function POST(req: NextRequest) {
-  await connectToDatabase();
-  const { userId, title, content } = await req.json();
-  if (!userId || !title || !content)
-    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  try {
+    await connectToDatabase();
+    const { userId, title, content } = await req.json();
+    if (!userId || !title || !content)
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
 
-  const note = await Note.create({
-    userId,
-    title,
-    content,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return NextResponse.json(note);
+    const note = await Note.create({
+      userId,
+      title,
+      content,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return NextResponse.json(note);
+  } catch (err: any) {
+    console.error("POST /api/notes error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -6,41 +6,65 @@ export async function GET(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await connectToDatabase();
-  const task = await Task.findById(params.id);
-  if (!task) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  try {
+    await connectToDatabase();
+    const task = await Task.findById(params.id);
+    if (!task) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    return NextResponse.json(task);
+  } catch (err: any) {
+    console.error("GET /api/tasks/[id] error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
   }
-  return NextResponse.json(task);
 }
 
 export async function PUT(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await connectToDatabase();
-  const body = await req.json();
-  const updated = await Task.findByIdAndUpdate(
-    params.id,
-    {
-      title: body.title,
-      description: body.description,
-      status: body.status,
-      priority: body.priority,
-      dueDate: body.dueDate,
-      updatedAt: new Date(),
-    },
-    { new: true, runValidators: true }
-  );
+  try {
+    await connectToDatabase();
+    const body = await req.json();
+    const updated = await Task.findByIdAndUpdate(
+      params.id,
+      {
+        title: body.title,
+        description: body.description,
+        status: body.status,
+        priority: body.priority,
+        dueDate: body.dueDate,
+        updatedAt: new Date(),
+      },
+      { new: true, runValidators: true }
+    );
 
-  return NextResponse.json(updated);
+    return NextResponse.json(updated);
+  } catch (err: any) {
+    console.error("PUT /api/tasks/[id] error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }
 
 export async function DELETE(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  await connectToDatabase();
-  await Task.findByIdAndDelete(params.id);
-  return new Response(null, { status: 204 });
+  try {
+    await connectToDatabase();
+    await Task.findByIdAndDelete(params.id);
+    return new Response(null, { status: 204 });
+  } catch (err: any) {
+    console.error("DELETE /api/tasks/[id] error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -3,12 +3,20 @@ import { connectToDatabase } from "@/lib/db";
 import Task from "@/lib/models/Task";
 
 export async function GET(req: NextRequest) {
-  await connectToDatabase();
-  const { searchParams } = new URL(req.url);
-  const userId = searchParams.get("userId");
-  const query = userId ? { userId } : {};
-  const tasks = await Task.find(query);
-  return NextResponse.json(tasks);
+  try {
+    await connectToDatabase();
+    const { searchParams } = new URL(req.url);
+    const userId = searchParams.get("userId");
+    const query = userId ? { userId } : {};
+    const tasks = await Task.find(query);
+    return NextResponse.json(tasks);
+  } catch (err: any) {
+    console.error("GET /api/tasks error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }
 
 // export async function GET(req: NextRequest) {
@@ -31,21 +39,29 @@ export async function GET(req: NextRequest) {
 //   return NextResponse.json(task, { status: 201 });
 // }
 export async function POST(req: NextRequest) {
-  await connectToDatabase();
-  const { userId, title, description, status, priority, dueDate } =
-    await req.json();
-  if (!userId || !title)
-    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  try {
+    await connectToDatabase();
+    const { userId, title, description, status, priority, dueDate } =
+      await req.json();
+    if (!userId || !title)
+      return NextResponse.json({ error: "Missing fields" }, { status: 400 });
 
-  const task = await Task.create({
-    userId,
-    title,
-    description,
-    status: status || "pending",
-    priority: priority || "medium",
-    dueDate,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
-  return NextResponse.json(task);
+    const task = await Task.create({
+      userId,
+      title,
+      description,
+      status: status || "pending",
+      priority: priority || "medium",
+      dueDate,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return NextResponse.json(task);
+  } catch (err: any) {
+    console.error("POST /api/tasks error", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholder environment variables
- document how to copy `.env.example` in README
- whitelist `.env.example` in `.gitignore`
- wrap API route handlers in try/catch for clearer 500 errors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a96fe2af0832faeaac354620ff189