### PR TITLE
Fix hooks to persist data to DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # MongoDB / Cosmos DB connection string
 MONGODB_URI="mongodb://<username>:<password>@<host>:<port>/?ssl=true&replicaSet=globaldb"
 # Database name (optional)
-DATABASE_NAME=pim
+DATABASE_NAME=pim-db
 
 # Firebase credentials (optional for auth features)
 NEXT_PUBLIC_FIREBASE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -100,3 +100,4 @@ cp .env.example .env.local
 ```
 
 At a minimum, set `MONGODB_URI` to your Cosmos DB connection string. Without this the API routes (e.g. `/api/contacts` and `/api/tasks`) will return a 500 error.
+The application uses a database named `pim-db`. You can override this by setting the `DATABASE_NAME` environment variable.

--- a/azure-functions/contacts/index.ts
+++ b/azure-functions/contacts/index.ts
@@ -1,7 +1,7 @@
 import { MongoClient, ObjectId } from "mongodb";
 
 const uri = process.env.MONGODB_URI as string;
-const dbName = process.env.DATABASE_NAME || "pim";
+const dbName = process.env.DATABASE_NAME || "pim-db";
 const client = new MongoClient(uri);
 
 async function getCollection() {

--- a/azure-functions/lib/db.ts
+++ b/azure-functions/lib/db.ts
@@ -7,6 +7,6 @@ export async function connectToDatabase() {
   if (mongoose.connection.readyState >= 1) return;
 
   return mongoose.connect(MONGODB_URI, {
-    dbName: "pim",
+    dbName: "pim-db",
   });
 }

--- a/azure-functions/notes/index.ts
+++ b/azure-functions/notes/index.ts
@@ -1,7 +1,7 @@
 import { MongoClient, ObjectId } from "mongodb";
 
 const uri = process.env.MONGODB_URI as string;
-const dbName = process.env.DATABASE_NAME || "pim";
+const dbName = process.env.DATABASE_NAME || "pim-db";
 const client = new MongoClient(uri);
 
 async function getCollection() {

--- a/azure-functions/tasks/index.ts
+++ b/azure-functions/tasks/index.ts
@@ -1,7 +1,7 @@
 import { MongoClient, ObjectId } from "mongodb";
 
 const uri = process.env.MONGODB_URI as string;
-const dbName = process.env.DATABASE_NAME || "pim";
+const dbName = process.env.DATABASE_NAME || "pim-db";
 const client = new MongoClient(uri);
 
 async function getCollection() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -231,11 +231,26 @@ export default function HomePage() {
                   Back to Dashboard
                 </button>
 
-                <div className="">
-                  {view === "notes" && <Notes />}
-                  {view === "tasks" && <Tasks userId={user.id} />}
-                  {view === "contacts" && <Contacts userId={user.id} />}
-                </div>
+                  <div className="">
+                    {view === "notes" && (
+                      <Notes
+                        userId={user.id}
+                        onBackToDashboard={() => setView("dashboard")}
+                      />
+                    )}
+                    {view === "tasks" && (
+                      <Tasks
+                        userId={user.id}
+                        onBackToDashboard={() => setView("dashboard")}
+                      />
+                    )}
+                    {view === "contacts" && (
+                      <Contacts
+                        userId={user.id}
+                        onBackToDashboard={() => setView("dashboard")}
+                      />
+                    )}
+                  </div>
               </motion.div>
             )}
 
@@ -268,11 +283,23 @@ export default function HomePage() {
                   </div>
                 </div>
 
-                <div className="">
-                  {view === "notes" && <Notes />}
-                  {view === "tasks" && <Tasks />}
-                  {view === "contacts" && <Contacts />}
-                </div>
+                  <div className="">
+                    {view === "notes" && (
+                      <Notes
+                        onBackToDashboard={() => setView("auth")}
+                      />
+                    )}
+                    {view === "tasks" && (
+                      <Tasks
+                        onBackToDashboard={() => setView("auth")}
+                      />
+                    )}
+                    {view === "contacts" && (
+                      <Contacts
+                        onBackToDashboard={() => setView("auth")}
+                      />
+                    )}
+                  </div>
               </motion.div>
             )}
           </motion.div>

--- a/src/components/Contacts.tsx
+++ b/src/components/Contacts.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { motion } from "framer-motion";
 
 type ContactsProps = {
-  userId: string;
+  userId?: string;
   onBackToDashboard: () => void;
 };
 

--- a/src/components/Notes.tsx
+++ b/src/components/Notes.tsx
@@ -5,11 +5,12 @@ import { useState } from "react";
 import { motion } from "framer-motion";
 
 type NotesProps = {
+  userId?: string;
   onBackToDashboard: () => void;
 };
 
-const Notes = ({ onBackToDashboard }: NotesProps) => {
-  const { notes, createNote, updateNote, deleteNote } = useNotes("");
+const Notes = ({ userId, onBackToDashboard }: NotesProps) => {
+  const { notes, createNote, updateNote, deleteNote } = useNotes(userId);
   const [isCreating, setIsCreating] = useState(false);
   const [editingNote, setEditingNote] = useState<Note | null>(null);
   const [newNote, setNewNote] = useState({ title: "", content: "" });

--- a/src/components/Tasks.tsx
+++ b/src/components/Tasks.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { motion } from "framer-motion";
 
 type TasksProps = {
-  userId: string;
+  userId?: string;
   onBackToDashboard: () => void;
 };
 

--- a/src/hooks/useContacts.ts
+++ b/src/hooks/useContacts.ts
@@ -94,7 +94,7 @@ export function useContacts(userId: string | undefined) {
 
   useEffect(() => {
     if (userId) {
-      fetch("/api/contacts")
+      fetch(`/api/contacts?userId=${userId}`)
         .then((res) => res.json())
         .then(setContacts)
         .catch(console.error);
@@ -109,6 +109,10 @@ export function useContacts(userId: string | undefined) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(contact),
     });
+    if (!res.ok) {
+      console.error(`Failed to create contact: ${res.status}`);
+      return;
+    }
     const newContact = await res.json();
     setContacts((prev) => [...prev, newContact]);
   };

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -83,7 +83,7 @@ export function useNotes(userId: string | undefined) {
   // Fetch from backend
   useEffect(() => {
     if (userId) {
-      fetch(`/api/notes`)
+      fetch(`/api/notes?userId=${userId}`)
         .then((res) => res.json())
         .then((data) => setNotes(data))
         .catch(console.error);
@@ -94,8 +94,12 @@ export function useNotes(userId: string | undefined) {
     const res = await fetch(`/api/notes`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title, content }),
+      body: JSON.stringify({ title, content, userId }),
     });
+    if (!res.ok) {
+      console.error(`Failed to create note: ${res.status}`);
+      return;
+    }
     const newNote = await res.json();
     setNotes((prev) => [...prev, newNote]);
   };

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -97,7 +97,7 @@ export function useTasks(userId: string | undefined) {
 
   useEffect(() => {
     if (userId) {
-      fetch("/api/tasks")
+      fetch(`/api/tasks?userId=${userId}`)
         .then((res) => res.json())
         .then(setTasks)
         .catch(console.error);
@@ -112,6 +112,10 @@ export function useTasks(userId: string | undefined) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(task),
     });
+    if (!res.ok) {
+      console.error(`Failed to create task: ${res.status}`);
+      return;
+    }
     const newTask = await res.json();
     setTasks((prev) => [...prev, newTask]);
   };


### PR DESCRIPTION
## Summary
- use `userId` in frontend hooks so new items are saved to MongoDB
- pass userId to components from the page
- allow Tasks and Contacts components to work without a user
- set default DB name to `pim-db` and document it

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ab2a4d9f4832fa28c0644baee786c