### PR TITLE
Fix key warnings and simplify tasks

### DIFF
--- a/src/components/Tasks.tsx
+++ b/src/components/Tasks.tsx
@@ -19,9 +19,7 @@ const Tasks = ({ userId, onBackToDashboard }: TasksProps) => {
     priority: "medium" as Task["priority"],
     dueDate: "",
   });
-  const [filter, setFilter] = useState<
-    "all" | "pending" | "in-progress" | "completed"
-  >("all");
+  const [filter, setFilter] = useState<"all" | "pending" | "completed">("all");
 
   const handleCreate = () => {
     if (newTask.title.trim()) {
@@ -82,13 +80,8 @@ const Tasks = ({ userId, onBackToDashboard }: TasksProps) => {
   };
 
   const toggleStatus = (task: Task) => {
-    const statusOrder: Task["status"][] = [
-      "pending",
-      "in-progress",
-      "completed",
-    ];
-    const currentIndex = statusOrder.indexOf(task.status);
-    const nextStatus = statusOrder[(currentIndex + 1) % statusOrder.length];
+    const nextStatus: Task["status"] =
+      task.status === "pending" ? "completed" : "pending";
     updateTask(task.id, { status: nextStatus });
   };
 
@@ -100,8 +93,6 @@ const Tasks = ({ userId, onBackToDashboard }: TasksProps) => {
     switch (status) {
       case "pending":
         return "text-yellow-400 bg-yellow-600/20";
-      case "in-progress":
-        return "text-blue-400 bg-blue-600/20";
       case "completed":
         return "text-green-400 bg-green-600/20";
     }
@@ -134,7 +125,7 @@ const Tasks = ({ userId, onBackToDashboard }: TasksProps) => {
       </div>
 
       <div className="flex gap-2 mb-4 flex-wrap">
-        {(["all", "pending", "in-progress", "completed"] as const).map(
+        {(["all", "pending", "completed"] as const).map(
           (filterType) => (
             <button
               key={filterType}

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -44,7 +44,7 @@ interface Contact extends BaseEntity {
 interface Task extends BaseEntity {
   title: string;
   description?: string;
-  status: "pending" | "in-progress" | "completed" | "cancelled";
+  status: "pending" | "completed" | "cancelled";
   priority: "low" | "medium" | "high" | "urgent";
   dueDate?: string;
   completedAt?: string;

--- a/src/hooks/useContacts.ts
+++ b/src/hooks/useContacts.ts
@@ -96,7 +96,14 @@ export function useContacts(userId: string | undefined) {
     if (userId) {
       fetch(`/api/contacts?userId=${userId}`)
         .then((res) => res.json())
-        .then(setContacts)
+        .then((data) =>
+          setContacts(
+            data.map((c: any) => ({
+              id: c._id,
+              ...c,
+            }))
+          )
+        )
         .catch(console.error);
     }
   }, [userId]);
@@ -114,7 +121,13 @@ export function useContacts(userId: string | undefined) {
       return;
     }
     const newContact = await res.json();
-    setContacts((prev) => [...prev, newContact]);
+    setContacts((prev) => [
+      ...prev,
+      {
+        id: newContact._id,
+        ...newContact,
+      },
+    ]);
   };
 
   const updateContact = async (id: string, updates: Partial<Contact>) => {
@@ -124,7 +137,9 @@ export function useContacts(userId: string | undefined) {
       body: JSON.stringify(updates),
     });
     const updated = await res.json();
-    setContacts((prev) => prev.map((c) => (c.id === id ? updated : c)));
+    setContacts((prev) =>
+      prev.map((c) => (c.id === id ? { id: updated._id, ...updated } : c))
+    );
   };
 
   const deleteContact = async (id: string) => {

--- a/src/hooks/useNotes.ts
+++ b/src/hooks/useNotes.ts
@@ -85,7 +85,14 @@ export function useNotes(userId: string | undefined) {
     if (userId) {
       fetch(`/api/notes?userId=${userId}`)
         .then((res) => res.json())
-        .then((data) => setNotes(data))
+        .then((data) =>
+          setNotes(
+            data.map((n: any) => ({
+              id: n._id,
+              ...n,
+            }))
+          )
+        )
         .catch(console.error);
     }
   }, [userId]);
@@ -101,7 +108,13 @@ export function useNotes(userId: string | undefined) {
       return;
     }
     const newNote = await res.json();
-    setNotes((prev) => [...prev, newNote]);
+    setNotes((prev) => [
+      ...prev,
+      {
+        id: newNote._id,
+        ...newNote,
+      },
+    ]);
   };
 
   const updateNote = async (id: string, updatedFields: Partial<Note>) => {
@@ -112,7 +125,9 @@ export function useNotes(userId: string | undefined) {
     });
     const updatedNote = await res.json();
     setNotes((prev) =>
-      prev.map((note) => (note.id === id ? updatedNote : note))
+      prev.map((note) =>
+        note.id === id ? { id: updatedNote._id, ...updatedNote } : note
+      )
     );
   };
 

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -6,7 +6,7 @@
 //   id: string;
 //   title: string;
 //   description: string;
-//   status: "pending" | "in-progress" | "completed";
+//   status: "pending" | "completed";
 //   priority: "low" | "medium" | "high";
 //   dueDate?: Date;
 //   createdAt: Date;
@@ -84,7 +84,7 @@ export interface Task {
   id: string;
   title: string;
   description: string;
-  status: "pending" | "in-progress" | "completed";
+  status: "pending" | "completed";
   priority: "low" | "medium" | "high";
   dueDate?: string;
   createdAt: string;
@@ -99,7 +99,14 @@ export function useTasks(userId: string | undefined) {
     if (userId) {
       fetch(`/api/tasks?userId=${userId}`)
         .then((res) => res.json())
-        .then(setTasks)
+        .then((data) =>
+          setTasks(
+            data.map((t: any) => ({
+              id: t._id,
+              ...t,
+            }))
+          )
+        )
         .catch(console.error);
     }
   }, [userId]);
@@ -117,7 +124,13 @@ export function useTasks(userId: string | undefined) {
       return;
     }
     const newTask = await res.json();
-    setTasks((prev) => [...prev, newTask]);
+    setTasks((prev) => [
+      ...prev,
+      {
+        id: newTask._id,
+        ...newTask,
+      },
+    ]);
   };
 
   const updateTask = async (id: string, updates: Partial<Task>) => {
@@ -127,7 +140,9 @@ export function useTasks(userId: string | undefined) {
       body: JSON.stringify(updates),
     });
     const updated = await res.json();
-    setTasks((prev) => prev.map((t) => (t.id === id ? updated : t)));
+    setTasks((prev) =>
+      prev.map((t) => (t.id === id ? { id: updated._id, ...updated } : t))
+    );
   };
 
   const deleteTask = async (id: string) => {

--- a/src/lib/models/Task.ts
+++ b/src/lib/models/Task.ts
@@ -7,7 +7,7 @@ const TaskSchema = new Schema(
     description: { type: String },
     status: {
       type: String,
-      enum: ["pending", "in-progress", "completed"],
+      enum: ["pending", "completed"],
       default: "pending",
     },
     priority: {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -189,7 +189,7 @@ export const tasksApi = {
     toDate.setDate(toDate.getDate() + days);
     return apiService.getAll("tasks", {
       dueDateTo: toDate.toISOString(),
-      status: "todo,in-progress",
+      status: "todo,pending",
     });
   },
 
@@ -198,7 +198,7 @@ export const tasksApi = {
     today.setHours(0, 0, 0, 0);
     return apiService.getAll("tasks", {
       dueDateTo: today.toISOString(),
-      status: "todo,in-progress",
+      status: "todo,pending",
     });
   },
 };


### PR DESCRIPTION
## Summary
- map `_id` to `id` in hooks for notes, contacts, and tasks
- restrict task status to `pending` or `completed`
- update task schema and API utilities
- adjust Tasks UI for new status

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ab6081ac8832f97ecf71582238424