### PR TITLE
Allow contacts to omit email addresses

### DIFF
--- a/src/hooks/useContacts.ts
+++ b/src/hooks/useContacts.ts
@@ -82,8 +82,8 @@ import { useEffect, useState } from "react";
 export interface Contact {
   id: string;
   name: string;
-  email: string;
-  phone?: string;
+  email: string | null;
+  phone: string | null;
   createdAt: string;
   updatedAt: string;
   userId: string;
@@ -108,6 +108,8 @@ export function useContacts(userId: string | undefined) {
             list.map((c: any) => ({
               id: c._id,
               ...c,
+              phone: c.phone ?? null,
+              email: c.email ?? null,
             }))
           );
         })
@@ -140,6 +142,8 @@ export function useContacts(userId: string | undefined) {
             list.map((c: any) => ({
               id: c._id,
               ...c,
+              phone: c.phone ?? null,
+              email: c.email ?? null,
             }))
           );
         })
@@ -157,8 +161,8 @@ export function useContacts(userId: string | undefined) {
     const tempContact: Contact = {
       id: tempId,
       name: contact.name,
-      email: contact.email,
-      phone: contact.phone,
+      email: contact.email ?? null,
+      phone: contact.phone ?? null,
       createdAt: nowIso,
       updatedAt: nowIso,
       userId: userId || "",
@@ -176,7 +180,16 @@ export function useContacts(userId: string | undefined) {
       if (!res.ok) throw new Error(`Failed to create contact: ${res.status}`);
       const newContact = await res.json();
       setContacts((prev) =>
-        prev.map((c) => (c.id === tempId ? { id: newContact._id, ...newContact } : c))
+        prev.map((c) =>
+          c.id === tempId
+            ? {
+                id: newContact._id,
+                ...newContact,
+                email: newContact.email ?? null,
+                phone: newContact.phone ?? null,
+              }
+            : c
+        )
       );
     } catch (err) {
       console.error(err);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -147,11 +147,16 @@ async function createTables() {
       id TEXT PRIMARY KEY,
       user_id TEXT NOT NULL,
       name TEXT NOT NULL,
-      email TEXT NOT NULL,
+      email TEXT,
       phone TEXT,
       created_at TIMESTAMPTZ NOT NULL,
       updated_at TIMESTAMPTZ NOT NULL
     );
+  `;
+
+  await sql`
+    ALTER TABLE contacts
+    ALTER COLUMN email DROP NOT NULL;
   `;
 
   await sql`


### PR DESCRIPTION
## Summary
- allow contacts to be created with either an email address or a phone number and persist null emails in the database
- relax update validation so contacts always keep at least one contact method and support clearing an email
- update contact hooks and UI validation to treat email and phone as optional individually and show fallback copy when email is missing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fe96dd7880832fb0bcb429d83c4aef